### PR TITLE
Remove Static Bookie Defaults to Default to Pulsar's Dynamic Defaults

### DIFF
--- a/pkg/pulsar/components/bookie/configmap.go
+++ b/pkg/pulsar/components/bookie/configmap.go
@@ -22,8 +22,6 @@ func MakeConfigMap(c *pulsarv1alpha1.PulsarCluster) *v1.ConfigMap {
 		},
 		Data: map[string]string{
 			"BOOKIE_MEM":                        BookieMemData,
-			"dbStorage_writeCacheMaxSizeMb":     DbStorage_writeCacheMaxSizeMb,
-			"dbStorage_readAheadCacheMaxSizeMb": DbStorage_readAheadCacheMaxSizeMb,
 			"zkServers":                         zookeeper.MakeServiceName(c),
 			"statsProviderClass":                StatsProviderClass,
 		},

--- a/pkg/pulsar/components/bookie/constant.go
+++ b/pkg/pulsar/components/bookie/constant.go
@@ -3,10 +3,6 @@ package bookie
 const (
 	BookieMemData = "\" -Xms64m -Xmx256m -XX:MaxDirectMemorySize=256m\""
 
-	DbStorage_writeCacheMaxSizeMb = "32"
-
-	DbStorage_readAheadCacheMaxSizeMb = "32"
-
 	StatsProviderClass = "org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider"
 
 	BookieJournalDataMountPath = "/pulsar/data/bookkeeper/journal"


### PR DESCRIPTION
Fixes https://github.com/sky-big/pulsar-operator/issues/18

Given that pulsar defaults to dynamic configurations that will better match user deployments, I think these static default values should be removed.